### PR TITLE
chore: update mithril to 2347.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM rust:bookworm AS rustbuilder
-ARG MITHRIL_VERSION=2342.0
+ARG MITHRIL_VERSION=2347.0
 ENV MITHRIL_VERSION=${MITHRIL_VERSION}
 WORKDIR /code
 RUN echo "Building tags/${MITHRIL_VERSION}..." \
-    && git clone https://github.com/input-output-hk/mithril.git \
+    && git clone https://github.com/input-output-hk/mithril.git --depth 1 -b ${MITHRIL_VERSION} \
     && cd mithril \
-    && git fetch --all --recurse-submodules --tags \
-    && git tag \
     && git checkout tags/${MITHRIL_VERSION} \
-    && cargo build --release -p mithril-client
+    && cargo build --release -p mithril-client-cli
 
-FROM debian:bookworm-slim as mithrill-client
+FROM debian:bookworm-slim as mithril-client
 COPY --from=rustbuilder /code/mithril/target/release/mithril-client /bin/
 RUN apt-get update -y \
     && apt-get install -y \


### PR DESCRIPTION
This also switches to a shallow clone of the mithril repo for speed