### PR TITLE
feat(docker): support commit SHA checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM rust:bookworm AS rustbuilder
-ARG MITHRIL_VERSION=2617.0
+FROM rust:slim-bookworm AS rustbuilder
+# Can be a git tag or commit SHA
+# 0f6d54dd9c229104d0bfcca670d320266899f0ca (0.13.19)
+ARG MITHRIL_VERSION=0f6d54dd9c229104d0bfcca670d320266899f0ca
 ENV MITHRIL_VERSION=${MITHRIL_VERSION}
+RUN apt-get update && apt-get install -y --no-install-recommends git make gcc libc6-dev
 WORKDIR /code
-RUN echo "Building tags/${MITHRIL_VERSION}..." \
-    && git clone https://github.com/input-output-hk/mithril.git --depth 1 -b ${MITHRIL_VERSION} \
+RUN echo "Building ${MITHRIL_VERSION}..." \
+    && git clone --filter=blob:none https://github.com/input-output-hk/mithril.git \
     && cd mithril \
-    && git checkout tags/${MITHRIL_VERSION} \
-    && cargo build --release -p mithril-client-cli
+    && git checkout ${MITHRIL_VERSION} \
+    && cargo build --release -p mithril-client-cli \
+    && strip target/release/mithril-client
 
 FROM ghcr.io/blinklabs-io/cardano-configs:20260707-2 AS cardano-configs
 
@@ -14,11 +18,7 @@ FROM debian:bookworm-slim AS mithril-client
 COPY --from=rustbuilder /code/mithril/target/release/mithril-client /bin/
 COPY --from=cardano-configs /config/ /opt/cardano/config/
 RUN apt-get update -y \
-    && apt-get install -y \
-       ca-certificates \
-       libssl3 \
-       llvm-14-runtime \
-       sqlite3 \
-       wget \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["/bin/mithril-client"]


### PR DESCRIPTION
Allow MITHRIL_VERSION to be a commit SHA by doing a full clone and direct checkout, instead of shallow clone restricted to tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support building the Mithril CLI from a tag or commit SHA by doing a full, blobless clone and checking out `MITHRIL_VERSION`. The image is smaller by using a slim Rust builder, stripping the `mithril-client` binary, and keeping only minimal runtime packages.

- **New Features**
  - Checkout `${MITHRIL_VERSION}` (tag or SHA) via `git clone --filter=blob:none` and direct `git checkout`.
  - Default `MITHRIL_VERSION` set to a specific commit SHA.
  - Use `rust:slim-bookworm`; install minimal build deps (`git`, `make`, `gcc`, `libc6-dev`) with `--no-install-recommends`; strip `mithril-client`; runtime keeps only `ca-certificates`.

- **Dependencies**
  - Update base `ghcr.io/blinklabs-io/cardano-configs` to `20260707-2`.

<sup>Written for commit e04742aca83139402551a3c627b19bd716d4e606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/docker-mithril-client/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Mithril source revision used during container builds.
  * Improved build flexibility by supporting direct checkout of specified revisions.
  * Reduced unnecessary runtime package installation in the container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->